### PR TITLE
Remove validate command line option

### DIFF
--- a/game-of-life/package.json
+++ b/game-of-life/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --use Math=JSMath --runtime none --importMemory --sourceMap --debug --validate --measure",
-    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat -d build/optimized.d.ts --use Math=JSMath -O3 --runtime none --importMemory --sourceMap --validate --measure",
+    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --use Math=JSMath --runtime none --importMemory --sourceMap --debug --measure",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat -d build/optimized.d.ts --use Math=JSMath -O3 --runtime none --importMemory --sourceMap --measure",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
     "start": "http-server . -o -c-1"
   },

--- a/i64/package.json
+++ b/i64/package.json
@@ -6,8 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
-    "asbuild:untouched": "asc assembly/i64.ts -t build/untouched.wat -b build/untouched.wasm --runtime none --validate --sourceMap --debug --measure",
-    "asbuild:optimized": "asc assembly/i64.ts -b build/optimized.wasm -t build/optimized.wat -d build/optimized.d.ts -O3 --runtime none --validate --sourceMap --measure",
+    "asbuild:untouched": "asc assembly/i64.ts -t build/untouched.wat -b build/untouched.wasm --runtime none --sourceMap --debug --measure",
+    "asbuild:optimized": "asc assembly/i64.ts -b build/optimized.wasm -t build/optimized.wat -d build/optimized.d.ts -O3 --runtime none --sourceMap --measure",
     "test": "node tests"
   },
   "files": [

--- a/interference/package.json
+++ b/interference/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --validate --sourceMap --runtime none --debug",
-    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --validate --sourceMap --runtime none --optimize",
+    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --sourceMap --runtime none --debug",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --sourceMap --runtime none --optimize",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
     "start": "http-server . -o -c-1"
   },

--- a/libm/package.json
+++ b/libm/package.json
@@ -7,8 +7,8 @@
   "types": "index.d.ts",
   "scripts": {
     "asbuild": "npm run asbuild:libm && npm run asbuild:libmf",
-    "asbuild:libm": "asc assembly/libm.ts -O3 -b build/libm.wasm -t build/libm.wat --runtime none --validate",
-    "asbuild:libmf": "asc assembly/libmf.ts -O3 -b build/libmf.wasm -t build/libmf.wat --runtime none --validate",
+    "asbuild:libm": "asc assembly/libm.ts -O3 -b build/libm.wasm -t build/libm.wat --runtime none",
+    "asbuild:libmf": "asc assembly/libmf.ts -O3 -b build/libmf.wasm -t build/libmf.wat --runtime none",
     "test": "node tests"
   },
   "files": [

--- a/loader/package.json
+++ b/loader/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --validate --sourceMap --debug",
-    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --validate --sourceMap --optimize",
+    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --sourceMap --debug",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --sourceMap --optimize",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
     "test": "node tests"
   },

--- a/mandelbrot/package.json
+++ b/mandelbrot/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --use Math=JSMath --runtime none --importMemory --sourceMap --debug --validate --measure",
-    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat -d build/optimized.d.ts --use Math=JSMath --runtime none -O3 --importMemory --sourceMap --validate --measure",
+    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --use Math=JSMath --runtime none --importMemory --sourceMap --debug --measure",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat -d build/optimized.d.ts --use Math=JSMath --runtime none -O3 --importMemory --sourceMap --measure",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
     "start": "http-server . -o -c-1"
   },

--- a/n-body/package.json
+++ b/n-body/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "asbuild:optimized": "asc assembly/index.ts -b build/as_nbody.wasm -t build/as_nbody.wat -O3 --validate --runtime none --noAssert --importMemory",
-    "asbuild:asmjs": "asc assembly/index.ts -a build/as_nbody.asm.js -O3 --validate --runtime none --noAssert && node scripts/postprocess-asmjs",
+    "asbuild:optimized": "asc assembly/index.ts -b build/as_nbody.wasm -t build/as_nbody.wat -O3 --runtime none --noAssert --importMemory",
+    "asbuild:asmjs": "asc assembly/index.ts -a build/as_nbody.asm.js -O3 --runtime none --noAssert && node scripts/postprocess-asmjs",
     "asbuild": "npm run asbuild:optimized && npm run asbuild:asmjs",
     "tsbuild": "tsc -p assembly -t ES2017 -m commonjs --outDir build",
     "rsbuild": "cd rust && RUSTFLAGS='-C link-arg=-s' cargo +nightly build --release",


### PR DESCRIPTION
Removes the `--validate` option, which is now enabled by default as of https://github.com/AssemblyScript/assemblyscript/pull/1258.